### PR TITLE
fix(ban_manager): Fixed ban command not working

### DIFF
--- a/cogs/ban_manager.py
+++ b/cogs/ban_manager.py
@@ -1,5 +1,6 @@
 import logging
 import discord
+import config
 from discord.ext import commands
 from discord import app_commands
 from datetime import datetime, timedelta, timezone

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+discord.py
+audioop-lts; python_version >= "3.13"
+urllib3
+pytz
+colorama
+requests
+python-dateutil
+pysftp
+beautifulsoup4
+asyncpraw
+unidecode


### PR DESCRIPTION
Fixed application did not respond command when banning member.
Before:
![image](https://github.com/user-attachments/assets/09e18f3c-9d6c-4b1b-8c46-513e51cd63a6)
After:
![image](https://github.com/user-attachments/assets/4536c0d3-6c3c-481f-8bcd-b06967fcb3d5)

Added requirement.txt with all needed bot libraries for easy fork setup.